### PR TITLE
Memory Leaks & Compiler Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Quote Droplet.xcworkspace/xcuserdata/daggerpov.xcuserdatad/UserInterfaceState.xc
 Quote Droplet.xcworkspace
 .DS_Store
 Quote Droplet.xcodeproj/xcshareddata/xcschemes/Quote Droplet.xcscheme
+Pods/Pods.xcodeproj/xcuserdata/daniel.xcuserdatad/xcschemes/xcschememanagement.plist
+Quote Droplet.xcodeproj/xcuserdata/daniel.xcuserdatad/xcschemes/xcschememanagement.plist

--- a/Quote Droplet.xcodeproj/project.pbxproj
+++ b/Quote Droplet.xcodeproj/project.pbxproj
@@ -62,8 +62,6 @@
 		DC8E76542CCDEB8E00F9EB0E /* MockAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8E76532CCDEB8A00F9EB0E /* MockAPIService.swift */; };
 		DC8E76552CCDEB8E00F9EB0E /* MockAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8E76532CCDEB8A00F9EB0E /* MockAPIService.swift */; };
 		DC96E93B2A9FE78300866D46 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAB2DA02A9FA91300A822D7 /* ContentView.swift */; };
-		DCA1E2A52C32576D00949BD3 /* sound-for-noti-water-drip-pixabay.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = DCA1E2A42C32576D00949BD3 /* sound-for-noti-water-drip-pixabay.mp3 */; };
-		DCA1E2A62C32576D00949BD3 /* sound-for-noti-water-drip-pixabay.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = DCA1E2A42C32576D00949BD3 /* sound-for-noti-water-drip-pixabay.mp3 */; };
 		DCAB2D9F2A9FA91300A822D7 /* QuoteDropletApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAB2D9E2A9FA91300A822D7 /* QuoteDropletApp.swift */; };
 		DCAB2DA12A9FA91300A822D7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAB2DA02A9FA91300A822D7 /* ContentView.swift */; };
 		DCAB2DA32A9FA91900A822D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DCAB2DA22A9FA91900A822D7 /* Assets.xcassets */; };
@@ -180,7 +178,6 @@
 		DC26EB932BF96FD4004CA84F /* DropletsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropletsView.swift; sourceTree = "<group>"; };
 		DC2998F92C4D9C5C0025D32E /* SingleQuoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleQuoteViewModel.swift; sourceTree = "<group>"; };
 		DC2998FE2C4D9C820025D32E /* sound-for-noti-water-drip-pixabay.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "sound-for-noti-water-drip-pixabay.mp3"; sourceTree = "<group>"; };
-		DC2998FF2C4D9C910025D32E /* sound-for-noti-water-drip-pixabay.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; name = "sound-for-noti-water-drip-pixabay.mp3"; path = "../../../../../Downloads/sound-for-noti-water-drip-pixabay.mp3"; sourceTree = "<group>"; };
 		DC2999062C4DBED40025D32E /* AuthorHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorHelper.swift; sourceTree = "<group>"; };
 		DC2999092C4DCE0B0025D32E /* AuthorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorView.swift; sourceTree = "<group>"; };
 		DC29990C2C4DF2350025D32E /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
@@ -200,7 +197,6 @@
 		DC8E764D2CCDE43000F9EB0E /* MockLocalQuoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalQuoteService.swift; sourceTree = "<group>"; };
 		DC8E76502CCDEACB00F9EB0E /* IAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPIService.swift; sourceTree = "<group>"; };
 		DC8E76532CCDEB8A00F9EB0E /* MockAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPIService.swift; sourceTree = "<group>"; };
-		DCA1E2A42C32576D00949BD3 /* sound-for-noti-water-drip-pixabay.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; name = "sound-for-noti-water-drip-pixabay.mp3"; path = "../../../../Downloads/sound-for-noti-water-drip-pixabay.mp3"; sourceTree = "<group>"; };
 		DCAB2D9B2A9FA91300A822D7 /* Quote Droplet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Quote Droplet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCAB2D9E2A9FA91300A822D7 /* QuoteDropletApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteDropletApp.swift; sourceTree = "<group>"; };
 		DCAB2DA02A9FA91300A822D7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -360,7 +356,6 @@
 			children = (
 				DCC0B3622CC9B154002DED7A /* Fonts.swift */,
 				DC2998FE2C4D9C820025D32E /* sound-for-noti-water-drip-pixabay.mp3 */,
-				DC2998FF2C4D9C910025D32E /* sound-for-noti-water-drip-pixabay.mp3 */,
 				DCAB2DA22A9FA91900A822D7 /* Assets.xcassets */,
 			);
 			path = Utils;
@@ -419,7 +414,6 @@
 				DCB1DA5B2CCC5FE900D823B0 /* Enums */,
 				DC0EFB8D2C4CB79100B4D46A /* Services */,
 				DC2998FC2C4D9C670025D32E /* Models */,
-				DCA1E2A42C32576D00949BD3 /* sound-for-noti-water-drip-pixabay.mp3 */,
 				DC14DCBF2BB25B9400F87C12 /* GoogleService-Info.plist */,
 				DCAB2DD02A9FBAB800A822D7 /* Info.plist */,
 				DCAB2D9E2A9FA91300A822D7 /* QuoteDropletApp.swift */,
@@ -647,7 +641,6 @@
 				DCAB2DA62A9FA91900A822D7 /* Preview Assets.xcassets in Resources */,
 				DC14DCC02BB25B9400F87C12 /* GoogleService-Info.plist in Resources */,
 				DCAB2DA32A9FA91900A822D7 /* Assets.xcassets in Resources */,
-				DCA1E2A52C32576D00949BD3 /* sound-for-noti-water-drip-pixabay.mp3 in Resources */,
 				DC7010E12BAE63DC008678CB /* QuotesBackup.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -656,7 +649,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCA1E2A62C32576D00949BD3 /* sound-for-noti-water-drip-pixabay.mp3 in Resources */,
 				DC7010E22BAE63DC008678CB /* QuotesBackup.json in Resources */,
 				DCAB2DBF2A9FA96100A822D7 /* Assets.xcassets in Resources */,
 				DC14DCC12BB25B9400F87C12 /* GoogleService-Info.plist in Resources */,

--- a/QuoteDroplet/ViewModels/AuthorHelper.swift
+++ b/QuoteDroplet/ViewModels/AuthorHelper.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-public func isAuthorValid (authorGiven: String?)-> Bool {
+public func isAuthorValid (authorGiven: String?) -> Bool {
     return (authorGiven != "Unknown Author" && authorGiven != "NULL" && authorGiven != "" && authorGiven != nil &&  (authorGiven?.isEmpty == false))
 }

--- a/QuoteDroplet/ViewModels/AuthorViewModel.swift
+++ b/QuoteDroplet/ViewModels/AuthorViewModel.swift
@@ -10,28 +10,26 @@ import Foundation
 class AuthorViewModel: ObservableObject {
     @Published var quotes: [Quote] = []
     @Published var isLoadingMore: Bool = false
-    static let quotesPerPage = 100
-    private var totalQuotesLoaded = 0
+    static let quotesPerPage: Int = 100
+    private var totalQuotesLoaded: Int = 0
+    static let maxQuotes: Int = 200
     
-    static let maxQuotes = 200
-    
-    let quote: Quote // given when made
-    
+    let quote: Quote
     let apiService: IAPIService
     let localQuotesService: ILocalQuotesService
-
+    
     init(quote: Quote, localQuotesService: ILocalQuotesService, apiService: IAPIService) {
         self.quote = quote
         self.localQuotesService = localQuotesService
         self.apiService = apiService
     }
     
-    func loadRemoteJSON<T: Decodable>(_ urlString: String, completion: @escaping  ((T) -> Void)) {
+    func loadRemoteJSON<T: Decodable>(_ urlString: String, completion: @escaping  ((T) -> Void)) -> Void {
         guard let url = URL(string: urlString) else {
             fatalError("Invalid URL")
         }
         
-        let request = URLRequest(url: url)
+        let request: URLRequest = URLRequest(url: url)
         URLSession.shared.dataTask(with: request) { data, response, error in
             guard let data = data else {
                 fatalError(error?.localizedDescription ?? "Unknown Error")
@@ -49,21 +47,21 @@ class AuthorViewModel: ObservableObject {
         }
     }
     
-    public func loadInitialQuotes() {
-        totalQuotesLoaded = 0
-        loadMoreQuotes() // Initial load
+    public func loadInitialQuotes() -> Void {
+        self.totalQuotesLoaded = 0
+        self.loadMoreQuotes() // Initial load
     }
     
-    public func loadMoreQuotes() {
-        guard !isLoadingMore else { return }
+    public func loadMoreQuotes() -> Void {
+        guard !self.isLoadingMore else { return }
         
-        isLoadingMore = true
-        let group = DispatchGroup()
+        self.isLoadingMore = true
+        let group: DispatchGroup = DispatchGroup()
         
-        guard let author: String = quote.author else { return }
-
+        guard let author: String = self.quote.author else { return }
+        
         apiService.getQuotesByAuthor(author: author) { [weak self] quotes, error in
-            guard let self = self else {return}
+            guard let self = self else { return }
             if let error = error {
                 print("Error fetching quotes: \(error)")
                 return
@@ -74,7 +72,7 @@ class AuthorViewModel: ObservableObject {
                 return
             }
             
-            let quotesToAppend = quotes.prefix(AuthorViewModel.quotesPerPage)
+            let quotesToAppend: [Quote] = Array(quotes.prefix(AuthorViewModel.quotesPerPage))
             
             for quote in quotesToAppend {
                 DispatchQueue.main.async {
@@ -86,7 +84,7 @@ class AuthorViewModel: ObservableObject {
         }
         
         group.notify(queue: .main) { [weak self] in
-            guard let self = self else {return}
+            guard let self = self else { return }
             self.isLoadingMore = false
             self.totalQuotesLoaded += AuthorViewModel.quotesPerPage
         }

--- a/QuoteDroplet/ViewModels/AuthorViewModel.swift
+++ b/QuoteDroplet/ViewModels/AuthorViewModel.swift
@@ -60,7 +60,10 @@ class AuthorViewModel: ObservableObject {
         isLoadingMore = true
         let group = DispatchGroup()
         
-        apiService.getQuotesByAuthor(author: quote.author!) { [weak self] quotes, error in
+        guard let author: String = quote.author else { return }
+
+        apiService.getQuotesByAuthor(author: author) { [weak self] quotes, error in
+            guard let self = self else {return}
             if let error = error {
                 print("Error fetching quotes: \(error)")
                 return
@@ -75,16 +78,18 @@ class AuthorViewModel: ObservableObject {
             
             for quote in quotesToAppend {
                 DispatchQueue.main.async {
-                    if !(self?.quotes.contains(where: { $0.id == quote.id }) ?? false) {
-                        self?.quotes.append(quote)
+                    if (self.quotes.contains(where: { $0.id == quote.id })){
+                        self.quotes.append(quote)
                     }
                 }
             }
         }
         
-        group.notify(queue: .main) {
+        group.notify(queue: .main) { [weak self] in
+            guard let self = self else {return}
             self.isLoadingMore = false
             self.totalQuotesLoaded += AuthorViewModel.quotesPerPage
         }
     }
 }
+

--- a/QuoteDroplet/ViewModels/CommunityViewModel.swift
+++ b/QuoteDroplet/ViewModels/CommunityViewModel.swift
@@ -19,10 +19,10 @@ class CommunityViewModel: ObservableObject {
         self.apiService = apiService
     }
     
-    public func getRecentQuotes() {
+    public func getRecentQuotes() -> Void {
         // Fetch recent quotes when the view appears
         apiService.getRecentQuotes(limit: 3) { [weak self] quotes, error in
-            guard let self = self else {return}
+            guard let self = self else { return }
             if let error = error {
                 print("Error fetching recent quotes: \(error)")
                 return

--- a/QuoteDroplet/ViewModels/CommunityViewModel.swift
+++ b/QuoteDroplet/ViewModels/CommunityViewModel.swift
@@ -21,15 +21,16 @@ class CommunityViewModel: ObservableObject {
     
     public func getRecentQuotes() {
         // Fetch recent quotes when the view appears
-        apiService.getRecentQuotes(limit: 3) { quotes, error in
+        apiService.getRecentQuotes(limit: 3) { [weak self] quotes, error in
+            guard let self = self else {return}
             if let error = error {
                 print("Error fetching recent quotes: \(error)")
                 return
             }
             
             if let quotes = quotes {
-                DispatchQueue.main.async { [weak self] in
-                    self?.recentQuotes = quotes
+                DispatchQueue.main.async {
+                    self.recentQuotes = quotes
                 }
             }
         }

--- a/QuoteDroplet/ViewModels/QuotesViewModel.swift
+++ b/QuoteDroplet/ViewModels/QuotesViewModel.swift
@@ -14,12 +14,12 @@ class QuotesViewModel: ObservableObject{
     @Published var counts: [String: Int] = [:]
     @Published var isTimePickerExpanded: Bool = false
     
-    private var showNotificationPicker = false
+    private var showNotificationPicker: Bool = false
     private var notificationTimeCase: NotificationTime = .defaultScheduled
     
     let localQuotesService: ILocalQuotesService
     let apiService: IAPIService
-
+    
     init(localQuotesService: ILocalQuotesService, apiService: IAPIService) {
         self.localQuotesService = localQuotesService
         self.apiService = apiService
@@ -28,21 +28,21 @@ class QuotesViewModel: ObservableObject{
         }
     }
     
-    public func initializeCounts() {
+    public func initializeCounts() -> Void {
         getCategoryCounts { [weak self] fetchedCounts in
             guard let self = self else { return }
             self.counts = fetchedCounts
         }
     }
-
-    public func fetchNotificationScheduledTimeInfo () {
+    
+    public func fetchNotificationScheduledTimeInfo () -> Void {
         self.notificationTimeCase = getIsDefaultConfigOverwritten() ? .previouslySelected : .defaultScheduled
         
         self.notificationScheduledTimeMessage = "You currently have daily notifications \((notificationTimeCase == .defaultScheduled) ? "automatically " : "")scheduled for: \n"
     }
     
     public func getNotificationTime() -> Date {
-        switch notificationTimeCase {
+        switch self.notificationTimeCase {
             case .previouslySelected:
                 return NotificationSchedulerService.previouslySelectedNotificationTime
             case .defaultScheduled:
@@ -60,35 +60,35 @@ class QuotesViewModel: ObservableObject{
         } else {
             self.notificationTime = NotificationSchedulerService.defaultScheduledNotificationTime
         }
-        isTimePickerExpanded.toggle()
+        self.isTimePickerExpanded.toggle()
     }
     
-    private func getCategoryCounts(completion: @escaping ([String: Int]) -> Void) {
-        let group = DispatchGroup()
+    private func getCategoryCounts(completion: @escaping ([String: Int]) -> Void) -> Void {
+        let group: DispatchGroup = DispatchGroup()
         for category in QuoteCategory.allCases {
             group.enter()
             if category == .bookmarkedQuotes {
-                getBookmarkedQuotesCount { [weak self] bookmarkedCount in
-                    guard let self = self else {return}
+                self.getBookmarkedQuotesCount { [weak self] bookmarkedCount in
+                    guard let self = self else { return }
                     self.counts[category.rawValue] = bookmarkedCount
                     group.leave()
                 }
             } else {
-                apiService.getCountForCategory(category: category) { [weak self] categoryCount in
-                    guard let self = self else {return}
+                self.apiService.getCountForCategory(category: category) { [weak self] categoryCount in
+                    guard let self = self else { return }
                     self.counts[category.rawValue] = categoryCount
                     group.leave()
                 }
             }
         }
         group.notify(queue: .main) { [weak self] in
-            guard let self = self else {return}
+            guard let self = self else { return }
             completion(counts)
         }
     }
     
-    private func getBookmarkedQuotesCount(completion: @escaping (Int) -> Void) {
-        let bookmarkedQuotes = localQuotesService.getBookmarkedQuotes()
+    private func getBookmarkedQuotesCount(completion: @escaping (Int) -> Void) -> Void {
+        let bookmarkedQuotes = self.localQuotesService.getBookmarkedQuotes()
         completion(bookmarkedQuotes.count)
     }
 }

--- a/QuoteDroplet/ViewModels/SearchViewModel.swift
+++ b/QuoteDroplet/ViewModels/SearchViewModel.swift
@@ -11,42 +11,42 @@ class SearchViewModel: ObservableObject {
     @Published var quotes: [Quote] = []
     @Published var searchText: String = ""
     @Published var activeCategory: QuoteCategory = .all
-
-    static let quotesPerPage = 5
-
+    
+    static let quotesPerPage: Int = 5
+    
     private var isLoadingMore: Bool = false
-    private let maxQuotes = 10
-    private var totalQuotesLoaded = 0
+    private let maxQuotes: Int = 10
+    private var totalQuotesLoaded: Int = 0
     
     let localQuotesService: ILocalQuotesService
     let apiService: IAPIService
-
+    
     init(localQuotesService: ILocalQuotesService, apiService: IAPIService) {
         self.localQuotesService = localQuotesService
         self.apiService = apiService
     }
     
-    public func loadQuotesBySearch() { 
+    public func loadQuotesBySearch() -> Void {
         guard !isLoadingMore else { return }
         
         self.quotes = []
         
-        isLoadingMore = true
-        let group = DispatchGroup()
+        self.isLoadingMore = true
+        let group: DispatchGroup = DispatchGroup()
         
         apiService.getQuotesBySearchKeyword(searchKeyword: searchText, searchCategory: activeCategory.rawValue.lowercased()) { [weak self] quotes, error in
             guard let self = self else { return }
-            if let error = error {
+            if let error: Error = error {
                 print("Error fetching quotes: \(error)")
                 return
             }
             
-            guard let quotes = quotes else {
+            guard let quotes: [Quote] = quotes else {
                 print("No quotes found.")
                 return
             }
             
-            let quotesToAppend = quotes.prefix(SearchViewModel.quotesPerPage)
+            let quotesToAppend: [Quote] = Array(quotes.prefix(SearchViewModel.quotesPerPage))
             
             for quote in quotesToAppend {
                 DispatchQueue.main.async {
@@ -58,7 +58,7 @@ class SearchViewModel: ObservableObject {
         }
         
         group.notify(queue: .main) { [weak self] in
-            guard let self = self else {return}
+            guard let self = self else { return }
             self.isLoadingMore = false
             self.totalQuotesLoaded += SearchViewModel.quotesPerPage
         }

--- a/QuoteDroplet/ViewModels/SearchViewModel.swift
+++ b/QuoteDroplet/ViewModels/SearchViewModel.swift
@@ -26,7 +26,7 @@ class SearchViewModel: ObservableObject {
         self.apiService = apiService
     }
     
-    public func loadQuotesBySearch() {
+    public func loadQuotesBySearch() { 
         guard !isLoadingMore else { return }
         
         self.quotes = []
@@ -35,6 +35,7 @@ class SearchViewModel: ObservableObject {
         let group = DispatchGroup()
         
         apiService.getQuotesBySearchKeyword(searchKeyword: searchText, searchCategory: activeCategory.rawValue.lowercased()) { [weak self] quotes, error in
+            guard let self = self else { return }
             if let error = error {
                 print("Error fetching quotes: \(error)")
                 return
@@ -49,14 +50,15 @@ class SearchViewModel: ObservableObject {
             
             for quote in quotesToAppend {
                 DispatchQueue.main.async {
-                    if !(self?.quotes.contains(where: { $0.id == quote.id }) ?? false) {
-                        self?.quotes.append(quote)
+                    if !self.quotes.contains(where: { $0.id == quote.id }) {
+                        self.quotes.append(quote)
                     }
                 }
             }
         }
         
-        group.notify(queue: .main) {
+        group.notify(queue: .main) { [weak self] in
+            guard let self = self else {return}
             self.isLoadingMore = false
             self.totalQuotesLoaded += SearchViewModel.quotesPerPage
         }

--- a/QuoteDroplet/ViewModels/SingleQuoteViewModel.swift
+++ b/QuoteDroplet/ViewModels/SingleQuoteViewModel.swift
@@ -52,51 +52,56 @@ class SingleQuoteViewModel: ObservableObject {
     public func getQuoteInfo() {
         isBookmarked = localQuotesService.isQuoteBookmarked(quote)
         
-        getQuoteLikeCountMethod(for: quote) { [weak self] fetchedLikeCount in // to avoid memory leaks
-            self?.likes = fetchedLikeCount
+        getQuoteLikeCountMethod(for: quote) { [weak self] fetchedLikeCount in
+            guard let self = self else { return }
+            self.likes = fetchedLikeCount
         }
         isLiked = localQuotesService.isQuoteLiked(quote)
     }
     
     func increaseInteractions() {
         DispatchQueue.main.async { [weak self] in
-            self?.interactions += 1
-            if (self?.interactions == 21) {
+            guard let self = self else { return }
+            self.interactions += 1
+            if (self.interactions == 21) {
                 // within app, so review should show
-                self?.requestReview()
+                self.requestReview()
             }
         }
     }
     
     func toggleCopy(for quote: Quote) {
         DispatchQueue.main.async { [weak self] in
-            self?.isCopied.toggle()
-            self?.increaseInteractions()
+            guard let self = self else { return }
+            self.isCopied.toggle()
+            self.increaseInteractions()
         }
     }
     
     func toggleBookmark(for quote: Quote) {
         DispatchQueue.main.async { [weak self] in // weak self to avoid memory leaks
-            self?.isBookmarked.toggle()
+            guard let self = self else { return }
+            self.isBookmarked.toggle()
             
-            if let isBookmarked = self?.isBookmarked {
+            if self.isBookmarked {
                 
-                self?.localQuotesService.saveBookmarkedQuote(quote: quote, isBookmarked: isBookmarked)
+                self.localQuotesService.saveBookmarkedQuote(quote: quote, isBookmarked: isBookmarked)
             }
             
-            self?.increaseInteractions()
+            self.increaseInteractions()
         }
     }
     
     func toggleLike(for quote: Quote) {
         DispatchQueue.main.async { [weak self] in // weak self to avoid memory leaks
-            self?.isLiked.toggle()
+            guard let self = self else { return }
+            self.isLiked.toggle()
             
-            if let isLiked = self?.isLiked {
-                self?.localQuotesService.saveLikedQuote(quote: quote, isLiked: isLiked)
+            if self.isLiked {
+                self.localQuotesService.saveLikedQuote(quote: quote, isLiked: isLiked)
             }
             
-            self?.increaseInteractions()
+            self.increaseInteractions()
         }
     }
     
@@ -111,7 +116,8 @@ class SingleQuoteViewModel: ObservableObject {
     func likeQuoteAction(for quote: Quote) {
         guard !isLiking else { return }
         
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {return}
             self.isLiking = true
         }
         
@@ -120,7 +126,8 @@ class SingleQuoteViewModel: ObservableObject {
         
         // Call the like/unlike API based on the current like status
         if isAlreadyLiked {
-            apiService.unlikeQuote(quoteID: quote.id) { updatedQuote, error in
+            apiService.unlikeQuote(quoteID: quote.id) { [weak self] updatedQuote, error in
+                guard let self = self else {return}
                 DispatchQueue.main.async {
                     if let updatedQuote = updatedQuote {
                         // Update likes count
@@ -130,7 +137,8 @@ class SingleQuoteViewModel: ObservableObject {
                 }
             }
         } else {
-            apiService.likeQuote(quoteID: quote.id) { updatedQuote, error in
+            apiService.likeQuote(quoteID: quote.id) { [weak self] updatedQuote, error in
+                guard let self = self else {return}
                 DispatchQueue.main.async {
                     if let updatedQuote = updatedQuote {
                         // Update likes count

--- a/QuoteDroplet/ViewModels/SingleQuoteViewModel.swift
+++ b/QuoteDroplet/ViewModels/SingleQuoteViewModel.swift
@@ -17,6 +17,7 @@ class SingleQuoteViewModel: ObservableObject {
     @Published var likes: Int = 0
     @Published var isLiking: Bool = false
     
+    // MARK: app review vars
     //------------------------------------------------------------------------------------
     @AppStorage("interactions", store: UserDefaults(suiteName: "group.selectedSettings"))
     var interactions: Int = 0
@@ -30,7 +31,7 @@ class SingleQuoteViewModel: ObservableObject {
     
     let localQuotesService: ILocalQuotesService
     let apiService: IAPIService
-
+    
     init(
         localQuotesService: ILocalQuotesService,
         apiService: IAPIService,
@@ -49,7 +50,7 @@ class SingleQuoteViewModel: ObservableObject {
         return isAuthorValid(authorGiven: quote.author) && from != .authorView
     }
     
-    public func getQuoteInfo() {
+    public func getQuoteInfo() -> Void {
         isBookmarked = localQuotesService.isQuoteBookmarked(quote)
         
         getQuoteLikeCountMethod(for: quote) { [weak self] fetchedLikeCount in
@@ -59,7 +60,7 @@ class SingleQuoteViewModel: ObservableObject {
         isLiked = localQuotesService.isQuoteLiked(quote)
     }
     
-    func increaseInteractions() {
+    func increaseInteractions() -> Void {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.interactions += 1
@@ -70,7 +71,7 @@ class SingleQuoteViewModel: ObservableObject {
         }
     }
     
-    func toggleCopy(for quote: Quote) {
+    func toggleCopy(for quote: Quote) -> Void {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.isCopied.toggle()
@@ -78,7 +79,7 @@ class SingleQuoteViewModel: ObservableObject {
         }
     }
     
-    func toggleBookmark(for quote: Quote) {
+    func toggleBookmark(for quote: Quote) -> Void {
         DispatchQueue.main.async { [weak self] in // weak self to avoid memory leaks
             guard let self = self else { return }
             self.isBookmarked.toggle()
@@ -92,7 +93,7 @@ class SingleQuoteViewModel: ObservableObject {
         }
     }
     
-    func toggleLike(for quote: Quote) {
+    func toggleLike(for quote: Quote) -> Void {
         DispatchQueue.main.async { [weak self] in // weak self to avoid memory leaks
             guard let self = self else { return }
             self.isLiked.toggle()
@@ -105,7 +106,7 @@ class SingleQuoteViewModel: ObservableObject {
         }
     }
     
-    func getQuoteLikeCountMethod(for quote: Quote, completion: @escaping (Int) -> Void) {
+    func getQuoteLikeCountMethod(for quote: Quote, completion: @escaping (Int) -> Void) -> Void {
         apiService.getLikeCountForQuote(quoteGiven: quote) { likeCount in
             DispatchQueue.main.async {
                 completion(likeCount)
@@ -113,21 +114,21 @@ class SingleQuoteViewModel: ObservableObject {
         }
     }
     
-    func likeQuoteAction(for quote: Quote) {
+    func likeQuoteAction(for quote: Quote) -> Void {
         guard !isLiking else { return }
         
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {return}
+            guard let self = self else { return }
             self.isLiking = true
         }
         
         // Check if the quote is already liked
-        let isAlreadyLiked = localQuotesService.isQuoteLiked(quote)
+        let isAlreadyLiked: Bool = localQuotesService.isQuoteLiked(quote)
         
         // Call the like/unlike API based on the current like status
         if isAlreadyLiked {
             apiService.unlikeQuote(quoteID: quote.id) { [weak self] updatedQuote, error in
-                guard let self = self else {return}
+                guard let self = self else { return }
                 DispatchQueue.main.async {
                     if let updatedQuote = updatedQuote {
                         // Update likes count
@@ -138,7 +139,7 @@ class SingleQuoteViewModel: ObservableObject {
             }
         } else {
             apiService.likeQuote(quoteID: quote.id) { [weak self] updatedQuote, error in
-                guard let self = self else {return}
+                guard let self = self else { return }
                 DispatchQueue.main.async {
                     if let updatedQuote = updatedQuote {
                         // Update likes count

--- a/QuoteDroplet/ViewModels/SubmitViewModel.swift
+++ b/QuoteDroplet/ViewModels/SubmitViewModel.swift
@@ -23,7 +23,8 @@ class SubmitViewModel: ObservableObject {
     }
     
     func addQuote() {
-        apiService.addQuote(text: quoteText, author: author, classification: selectedCategory.rawValue) { success, error in
+        apiService.addQuote(text: quoteText, author: author, classification: selectedCategory.rawValue) { [weak self] success, error in
+            guard let self = self else {return}
             if success {
                 self.submissionMessage = "Thanks for submitting a quote. It is now awaiting approval to be added to this app's quote database."
                 // Set showSubmissionReceivedAlert to true after successful submission

--- a/QuoteDroplet/ViewModels/SubmitViewModel.swift
+++ b/QuoteDroplet/ViewModels/SubmitViewModel.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 class SubmitViewModel: ObservableObject {
-    @Published var isAddingQuote = false
+    @Published var isAddingQuote: Bool = false
     @Published var selectedCategory: QuoteCategory = .all
-    @Published var submissionMessage = ""
-    @Published var showSubmissionReceivedAlert = false
-    @Published var showSubmissionInfoAlert = false
-    @Published var quoteText = ""
-    @Published var author = ""
+    @Published var submissionMessage: String = ""
+    @Published var showSubmissionReceivedAlert: Bool = false
+    @Published var showSubmissionInfoAlert: Bool = false
+    @Published var quoteText: String = ""
+    @Published var author: String = ""
     
     let apiService: IAPIService
     
@@ -22,9 +22,9 @@ class SubmitViewModel: ObservableObject {
         self.apiService = apiService
     }
     
-    func addQuote() {
+    func addQuote() -> Void {
         apiService.addQuote(text: quoteText, author: author, classification: selectedCategory.rawValue) { [weak self] success, error in
-            guard let self = self else {return}
+            guard let self = self else { return }
             if success {
                 self.submissionMessage = "Thanks for submitting a quote. It is now awaiting approval to be added to this app's quote database."
                 // Set showSubmissionReceivedAlert to true after successful submission

--- a/QuoteDroplet/Views/SubViews/SingleQuoteView.swift
+++ b/QuoteDroplet/Views/SubViews/SingleQuoteView.swift
@@ -123,12 +123,14 @@ extension SingleQuoteView {
                 Image(systemName: "doc.on.doc")
                     .modifier(QuoteInteractionButtonStyling())
             }.padding(.leading, 5)
-
-            ShareLink(item: URL(string: "https://apps.apple.com/us/app/quote-droplet/id6455084603")!, message: Text("From the Quote Droplet app:\n\n\"\(quote.text)\"\(wholeAuthorText)")) {
-                Image(systemName: "square.and.arrow.up")
-                    .modifier(QuoteInteractionButtonStyling())
+            
+            if let url = URL(string: "https://apps.apple.com/us/app/quote-droplet/id6455084603") {
+                ShareLink(item: url, message: Text("From the Quote Droplet app:\n\n\"\(quote.text)\"\(wholeAuthorText)")) {
+                    Image(systemName: "square.and.arrow.up")
+                        .modifier(QuoteInteractionButtonStyling())
+                        .padding(.leading, 5)
+                }
             }
-            .padding(.leading, 5)
 
             Spacer()
 

--- a/QuoteDroplet/Views/TabViews/DropletsView.swift
+++ b/QuoteDroplet/Views/TabViews/DropletsView.swift
@@ -137,7 +137,7 @@ extension DropletsView {
                         viewModel.checkMoreQuotesNeeded()
                     }
                 if viewModel.checkLimitReached() {
-                    Text("You've reached the quote limit of \(viewModel.maxQuotes). Maybe take a break?")
+                    Text("You've reached the quote limit of \(DropletsViewModel.maxQuotes). Maybe take a break?")
                         .modifier(QuotesPageTextStyling())
                 }
                 Spacer()

--- a/QuoteDroplet_Tests/AuthorViewModel_Tests.swift
+++ b/QuoteDroplet_Tests/AuthorViewModel_Tests.swift
@@ -8,10 +8,11 @@
 import Testing
 @testable import Quote_Droplet
 
-@Suite("Author View Model Tests") struct AuthorViewModel_Tests {
+@Suite("Author View Model Tests", .serialized) final class AuthorViewModel_Tests {
     let mockQuote: Quote
     let mockAPIService: MockAPIService
     let sut: AuthorViewModel
+	weak var weakSUT: AuthorViewModel?
     init () {
         self.mockQuote = Quote.mockQuote()
         self.mockAPIService = MockAPIService()
@@ -20,7 +21,12 @@ import Testing
             localQuotesService: MockLocalQuotesService(),
             apiService: mockAPIService
         )
+		self.weakSUT = self.sut
     }
+
+	deinit {
+		// #expect(weakSUT == nil)
+	}
 
     @Test func initialization() {
         // Test initial values

--- a/QuoteDroplet_Tests/CommunityViewModel_Tests.swift
+++ b/QuoteDroplet_Tests/CommunityViewModel_Tests.swift
@@ -9,15 +9,21 @@ import Testing
 @testable import Quote_Droplet
 import Foundation
 
-@Suite("Community View Model Tests") struct CommunityViewModel_Tests {
+@Suite("Community View Model Tests", .serialized) final class CommunityViewModel_Tests {
 
     let mockAPIService: MockAPIService
     let sut: CommunityViewModel
+	weak var weakSUT: CommunityViewModel?
 
     init() {
         self.mockAPIService = MockAPIService()
-        self.sut = CommunityViewModel(localQuotesService: MockLocalQuotesService(), apiService: mockAPIService)
-    }
+		self.sut = CommunityViewModel(localQuotesService: MockLocalQuotesService(), apiService: mockAPIService)
+		self.weakSUT = self.sut
+	}
+
+	deinit {
+		// #expect(weakSUT == nil)
+	}
 
     @Test func getRecentQuotes_success() async throws {
         let firstMockQuote: Quote = Quote.mockQuote()

--- a/QuoteDroplet_Tests/DropletsViewModel_Tests.swift
+++ b/QuoteDroplet_Tests/DropletsViewModel_Tests.swift
@@ -59,13 +59,13 @@ import Testing
      */
 
     @Test func checkMoreQuotesNeeded() async throws {
-        sut.quotes = [Quote](repeating: Quote.mockQuote(), count: sut.maxQuotes - 1)
+        sut.quotes = [Quote](repeating: Quote.mockQuote(), count: DropletsViewModel.maxQuotes - 1)
         #expect(!sut.checkLimitReached())
 
         sut.checkMoreQuotesNeeded()
 
         #expect(sut.quotes.count > 0)
-        #expect(sut.quotes.count <= sut.maxQuotes)
+        #expect(sut.quotes.count <= DropletsViewModel.maxQuotes)
     }
 
     @Test func getPageSpecificQuotes_feed() {
@@ -84,7 +84,7 @@ import Testing
 
     @Test func checkLimitReached() {
         sut.setSelected(newValue: .feed)
-        sut.quotes = [Quote](repeating: Quote.mockQuote(), count: sut.maxQuotes)
+        sut.quotes = [Quote](repeating: Quote.mockQuote(), count: DropletsViewModel.maxQuotes)
 
         #expect(sut.checkLimitReached())
     }

--- a/QuoteDroplet_Tests/DropletsViewModel_Tests.swift
+++ b/QuoteDroplet_Tests/DropletsViewModel_Tests.swift
@@ -8,16 +8,22 @@
 import Testing
 @testable import Quote_Droplet
 
-@Suite("Droplets View Model Tests") struct DropletsViewModel_Tests {
+@Suite("Droplets View Model Tests", .serialized) final class DropletsViewModel_Tests {
     let mockAPIService: MockAPIService
     let sut: DropletsViewModel
+	weak var weakSUT: DropletsViewModel?
     init() {
         self.mockAPIService = MockAPIService()
         self.sut = DropletsViewModel(
             localQuotesService: MockLocalQuotesService(),
             apiService: mockAPIService
         )
+		self.weakSUT = self.sut
     }
+
+	deinit {
+		// #expect(weakSUT == nil)
+	}
 
     @Test func setSelected() {
         #expect(sut.selected == SelectedPage.feed)

--- a/QuoteDroplet_Tests/QuotesViewModel_Tests.swift
+++ b/QuoteDroplet_Tests/QuotesViewModel_Tests.swift
@@ -9,17 +9,23 @@ import Testing
 @testable import Quote_Droplet
 import Foundation
 
-@Suite("Quotes View Model Tests") struct QuotesViewModel_Tests {
+@Suite("Quotes View Model Tests", .serialized) final class QuotesViewModel_Tests {
     let mockAPIService: MockAPIService
     let sut: QuotesViewModel
+	weak var weakSUT: QuotesViewModel?
 
     init() {
         self.mockAPIService = MockAPIService()
         self.sut = QuotesViewModel(
             localQuotesService: MockLocalQuotesService(),
             apiService: mockAPIService
-        )
-    }
+		)
+		self.weakSUT = self.sut
+	}
+
+	deinit {
+		// #expect(weakSUT == nil)
+	}
 
     @Test func initializeCounts_success() async {
         // Configure the mock API to return expected category counts

--- a/QuoteDroplet_Tests/SearchViewModel_Tests.swift
+++ b/QuoteDroplet_Tests/SearchViewModel_Tests.swift
@@ -9,18 +9,24 @@ import Testing
 @testable import Quote_Droplet
 import Foundation
 
-@Suite("Search View Model Tests")
-struct SearchViewModel_Tests {
+@Suite("Search View Model Tests", .serialized)
+final class SearchViewModel_Tests {
     let mockAPIService: MockAPIService
     let sut: SearchViewModel
+	weak var weakSUT: SearchViewModel?
 
     init() {
         self.mockAPIService = MockAPIService()
         self.sut = SearchViewModel(
             localQuotesService: MockLocalQuotesService(),
             apiService: mockAPIService
-        )
-    }
+		)
+		self.weakSUT = self.sut
+	}
+
+	deinit {
+		// #expect(weakSUT == nil)
+	}
 
     @Test
     func loadQuotesBySearch_successfulFetch_updatesQuotesList() async {

--- a/QuoteDroplet_Tests/SingleQuoteViewModel_Tests.swift
+++ b/QuoteDroplet_Tests/SingleQuoteViewModel_Tests.swift
@@ -7,12 +7,14 @@
 import Testing
 @testable import Quote_Droplet
 
-@Suite("Single Quote View Model Tests") struct SingleQuoteViewModel_Tests {
+@Suite("Single Quote View Model Tests", .serialized) final class SingleQuoteViewModel_Tests {
 
     let mockQuote: Quote
     let mockLocalQuotesService: MockLocalQuotesService
     let mockAPIService: MockAPIService
     let sut: SingleQuoteViewModel
+	weak var weakSUT: SingleQuoteViewModel?
+
     @MainActor init () {
         self.mockQuote = Quote.mockQuote()
         self.mockLocalQuotesService = MockLocalQuotesService()
@@ -21,8 +23,13 @@ import Testing
             localQuotesService: mockLocalQuotesService,
             apiService: mockAPIService,
             quote: mockQuote
-        )
-    }
+		)
+		self.weakSUT = self.sut
+	}
+
+	deinit {
+		// #expect(weakSUT == nil)
+	}
 
     @MainActor @Test func getQuoteInfo_setsLikeAndBookmarkStatus() {
         // Set mock service responses

--- a/QuoteDroplet_Tests/SubmitViewModel_Tests.swift
+++ b/QuoteDroplet_Tests/SubmitViewModel_Tests.swift
@@ -9,14 +9,20 @@ import Testing
 @testable import Quote_Droplet
 import Foundation
 
-@Suite("Submit View Model Tests") struct SubmitViewModel_Tests {
+@Suite("Submit View Model Tests", .serialized) final class SubmitViewModel_Tests {
     let mockAPIService: MockAPIService
     let sut: SubmitViewModel
+	weak var weakSUT: SubmitViewModel?
 
     init() {
         self.mockAPIService = MockAPIService()
-        self.sut = SubmitViewModel(apiService: mockAPIService)
-    }
+		self.sut = SubmitViewModel(apiService: mockAPIService)
+		self.weakSUT = self.sut
+	}
+
+	deinit {
+		// #expect(weakSUT == nil)
+	}
 
     @Test func addQuote_successfulSubmission_updatesState() async {
         // Configure the mock service for a successful submission


### PR DESCRIPTION
- Used `[weak self]` in closures, in conjunction with `guard let self = self else { return }` early-exits, to prevent memory leaks (from retain cycles between strongly referenced objects)
- Specified all variable types & function return types in all View Models, to optimize compiler (it won't have to implicitly figure out types)
- Changed test view model `structs` -> `final class`
    - See my Stackoverflow answer for why here: https://stackoverflow.com/a/79135798/13368695
- Laid groundwork to test for memory leaks, using Swift Testing de-initializers (similar to XCTest's "tear-down"), as I explain in the question on Stackoverflow: https://stackoverflow.com/a/79135798/13368695

- Will fix up current tests first, then implement this. For now, commented out `#expects` checks ("asserts" in XCTest terms):

